### PR TITLE
Implement short-term stock scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ pip install -r requirements.txt
 
 Run the analysis script from the command line. The following example fetches
 data for Apple (AAPL) between January and December 2023 and prints the latest
-rows including indicators:
+rows including indicators. You can also compute a short-term score (1-100)
+combining several technical and fundamental metrics:
 
 ```bash
 python stock_analysis.py AAPL --start 2023-01-01 --end 2023-12-31
 
 # save results to CSV
 python stock_analysis.py AAPL --start 2023-01-01 --end 2023-12-31 --csv aapl.csv
+
+# print short-term score
+python stock_analysis.py AAPL --start 2023-01-01 --end 2023-12-31 --score
 ```
 
 The module can also be imported in your own scripts to fetch data and compute

--- a/stock_analysis.py
+++ b/stock_analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 import yfinance as yf
+from typing import Dict
 
 
 class DownloadError(Exception):
@@ -59,6 +60,104 @@ def analyze_ticker(ticker: str, start: str, end: str) -> pd.DataFrame:
     return calculate_indicators(df)
 
 
+def fetch_fundamentals(ticker: str) -> Dict[str, float]:
+    """Return a dictionary with basic fundamental metrics using yfinance."""
+    info = {}
+    try:
+        info = yf.Ticker(ticker).info
+    except Exception:
+        # Ignore errors and return empty dict
+        return {}
+
+    keys = [
+        "trailingPE",
+        "earningsQuarterlyGrowth",
+        "debtToEquity",
+        "revenueQuarterlyGrowth",
+    ]
+    return {k: info.get(k) for k in keys if k in info}
+
+
+def compute_score(df: pd.DataFrame, fundamentals: Dict[str, float]) -> float:
+    """Compute a simple 1-100 short-term score using technical and fundamental data."""
+    # Technical scores
+    latest = df.iloc[-1]
+    score = 0.0
+
+    rsi = latest.get("RSI", 50)
+    if rsi < 30:
+        score += 15
+    elif rsi > 70:
+        score += 0
+    else:
+        score += 7.5
+
+    macd = latest.get("MACD", 0)
+    macd_signal = latest.get("MACD_signal", 0)
+    if macd > macd_signal:
+        score += 20
+
+    close = latest.get("Close")
+    bb_upper = latest.get("BB_upper")
+    bb_lower = latest.get("BB_lower")
+    if close is not None and bb_lower is not None and close <= bb_lower:
+        score += 10
+    elif close is not None and bb_upper is not None and close >= bb_upper:
+        score += 0
+    else:
+        score += 5
+
+    sma20 = latest.get("SMA_20")
+    sma50 = latest.get("SMA_50")
+    if close is not None and sma20 is not None and close > sma20:
+        score += 7
+    if close is not None and sma50 is not None and close > sma50:
+        score += 8
+    if sma20 is not None and sma50 is not None and sma20 > sma50:
+        score += 0
+
+    # Fundamental scores
+    pe = fundamentals.get("trailingPE")
+    if pe is not None:
+        if pe < 15:
+            score += 10
+        elif pe <= 25:
+            score += 5
+
+    eg = fundamentals.get("earningsQuarterlyGrowth")
+    if eg is not None:
+        if eg > 0.2:
+            score += 15
+        elif eg > 0.1:
+            score += 10
+        elif eg > 0:
+            score += 5
+
+    de_ratio = fundamentals.get("debtToEquity")
+    if de_ratio is not None:
+        if de_ratio < 100:
+            score += 5
+        elif de_ratio < 200:
+            score += 2.5
+
+    rev_growth = fundamentals.get("revenueQuarterlyGrowth")
+    if rev_growth is not None:
+        if rev_growth > 0.1:
+            score += 10
+        elif rev_growth > 0:
+            score += 5
+
+    # Bound score between 0 and 100
+    return max(0.0, min(100.0, score))
+
+
+def score_ticker(ticker: str, start: str, end: str) -> float:
+    """Convenience helper to analyze a ticker and return its score."""
+    df = analyze_ticker(ticker, start, end)
+    fundamentals = fetch_fundamentals(ticker)
+    return compute_score(df, fundamentals)
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -67,12 +166,24 @@ if __name__ == "__main__":
     parser.add_argument("--start", default="2023-01-01", help="Start date YYYY-MM-DD")
     parser.add_argument("--end", default="2023-12-31", help="End date YYYY-MM-DD")
     parser.add_argument("--csv", help="Optional path to save results as CSV")
+    parser.add_argument(
+        "--score",
+        action="store_true",
+        help="Print 1-100 short-term score based on technicals and fundamentals",
+    )
     args = parser.parse_args()
 
     try:
         data = analyze_ticker(args.ticker, start=args.start, end=args.end)
     except DownloadError as exc:
         parser.error(str(exc))
+
+    if args.score:
+        try:
+            score = score_ticker(args.ticker, args.start, args.end)
+            print(f"Short-term score: {score:.1f}/100")
+        except DownloadError as exc:
+            parser.error(str(exc))
 
     if args.csv:
         data.to_csv(args.csv)


### PR DESCRIPTION
## Summary
- add short-term scoring functions using technical and fundamental data
- expose `--score` CLI option
- document scoring usage in README

## Testing
- `python -m py_compile stock_analysis.py`
- `python stock_analysis.py AAPL --start 2023-01-01 --end 2023-12-31 --score` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840cf990b588328bc04f71b0896f4ac