### PR TITLE
Switch to Polygon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Stock Market Analysis Tool
 
 This repository contains simple utilities for downloading historical stock
-prices and computing common technical indicators. It relies on the
-[yfinance](https://github.com/ranaroussi/yfinance) package to access data
-from Yahoo Finance.
+prices and computing common technical indicators. Data is now fetched via the
+[Polygon.io](https://polygon.io/) API using the `polygon` client. Set the
+`POLYGON_API_KEY` environment variable with your API key before running the
+tools.
 
 ## Features
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 numpy
 matplotlib
-yfinance
+polygon-api-client

--- a/testing.py
+++ b/testing.py
@@ -1,15 +1,16 @@
 import pandas as pd
-import numpy as np 
-import matplotlib.pyplot as plt 
-import yfinance as yf 
+import numpy as np
+import matplotlib.pyplot as plt
+
+from stock_analysis import fetch_data
  
 ticker_symbol1 = 'TSLA'
 ticker_symbol2 = 'AAPL'
 start_date = '2023-01-01'
 end_date = '2023-12-15'
 
-stock_data1 = yf.download(ticker_symbol1, start=start_date, end=end_date)
-stock_data2 = yf.download(ticker_symbol2, start=start_date, end=end_date)
+stock_data1 = fetch_data(ticker_symbol1, start=start_date, end=end_date)
+stock_data2 = fetch_data(ticker_symbol2, start=start_date, end=end_date)
 
 #data inspection and cleaning
 print(stock_data1.head())


### PR DESCRIPTION
## Summary
- use Polygon API client instead of yfinance for historical data
- document `POLYGON_API_KEY` environment variable
- drop yfinance dependency
- update example `testing.py` to call `fetch_data`

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile stock_analysis.py testing.py`
- `POLYGON_API_KEY=… python stock_analysis.py AAPL --start 2023-01-01 --end 2023-01-10` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840da77c1d48328af98983209d5eb54